### PR TITLE
Fix CSV download for videos

### DIFF
--- a/app.py
+++ b/app.py
@@ -446,6 +446,14 @@ def download_csv(table_type):
             response = client.models.fetch(
                 limit=1000  # Fetch more data for download
             )
+        elif table_type == 'videos':
+            device_id = request.args.get('device_id')
+            if not device_id:
+                return jsonify({'error': 'device_id is required for videos'}), 400
+            response = client.videos.fetch(
+                device_id=device_id,
+                limit=1000  # Fetch more data for download
+            )
         else:
             return jsonify({'error': 'Invalid table type'}), 400
         
@@ -574,7 +582,7 @@ def view_device_videos(device_id):
     }
     
     # Create download URL
-    download_url = url_for('download_csv', table_type=f"videos_{device_id}")
+    download_url = url_for('download_csv', table_type='videos', device_id=device_id)
     
     return render_template('videos.html', 
                            device_id=device_id, 

--- a/templates/videos.html
+++ b/templates/videos.html
@@ -8,6 +8,7 @@
     <h2>Videos for Device {{ device_id }}</h2>
     <div class="mb-3">
         <a href="{{ url_for('view_device', device_id=device_id) }}" class="btn btn-secondary">Back to Device Overview</a>
+        <a href="{{ download_url }}" class="btn btn-secondary ml-2">Download CSV</a>
     </div>
 
     {% if items %}


### PR DESCRIPTION
## Summary
- support video CSV export
- pass correct download URL to video page
- add a Download CSV button on the video list page

## Testing
- `pytest -q`
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68437bfac3988326a134610692aab1e6