### PR TITLE
Add per-page limit selector for classifications

### DIFF
--- a/static/js/bbox_overlays.js
+++ b/static/js/bbox_overlays.js
@@ -1,6 +1,8 @@
 console.log('=== bbox_overlay_script included ===');
 var modalImages = [];
 var currentModalIndex = -1;
+var prevBtn = null;
+var nextBtn = null;
 function drawSvgBbox(img, svg, bbox) {
     if (!bbox || bbox.length !== 4 || (bbox[0] === 0 && bbox[1] === 0 && bbox[2] === 0 && bbox[3] === 0)) return;
     // Use displayed size
@@ -114,6 +116,12 @@ function showModalForIndex(index) {
     var bbox = null;
     try { if (bboxStr) bbox = JSON.parse(bboxStr); } catch (e) {}
     showModalWithImageAndBbox(img.getAttribute('data-image-url'), bbox);
+    if (prevBtn) {
+        prevBtn.style.display = index <= 0 ? 'none' : 'block';
+    }
+    if (nextBtn) {
+        nextBtn.style.display = index >= modalImages.length - 1 ? 'none' : 'block';
+    }
     if (window.$ && $('#imageModal').modal) {
         $('#imageModal').modal('show');
     }
@@ -125,31 +133,24 @@ document.addEventListener('DOMContentLoaded', function () {
     modalImages.forEach(function (img, idx) {
         img.dataset.modalIndex = idx;
         img.addEventListener('click', function () {
-            var bboxStr = img.getAttribute('data-bbox');
-            var bbox = null;
-            currentModalIndex = idx;
-            try { if (bboxStr) bbox = JSON.parse(bboxStr); } catch (e) {}
-            showModalWithImageAndBbox(img.getAttribute('data-image-url'), bbox);
-            if (window.$ && $('#imageModal').modal) {
-                $('#imageModal').modal('show');
-            }
+            showModalForIndex(idx);
         });
     });
 
-    var prevBtn = document.getElementById('modal-prev');
-    var nextBtn = document.getElementById('modal-next');
+    prevBtn = document.getElementById('modal-prev');
+    nextBtn = document.getElementById('modal-next');
     if (prevBtn) {
         prevBtn.addEventListener('click', function () {
-            if (modalImages.length === 0) return;
-            var newIndex = (currentModalIndex - 1 + modalImages.length) % modalImages.length;
-            showModalForIndex(newIndex);
+            if (currentModalIndex > 0) {
+                showModalForIndex(currentModalIndex - 1);
+            }
         });
     }
     if (nextBtn) {
         nextBtn.addEventListener('click', function () {
-            if (modalImages.length === 0) return;
-            var newIndex = (currentModalIndex + 1) % modalImages.length;
-            showModalForIndex(newIndex);
+            if (currentModalIndex < modalImages.length - 1) {
+                showModalForIndex(currentModalIndex + 1);
+            }
         });
     }
 

--- a/static/js/bbox_overlays.js
+++ b/static/js/bbox_overlays.js
@@ -3,6 +3,7 @@ var modalImages = [];
 var currentModalIndex = -1;
 var prevBtn = null;
 var nextBtn = null;
+var modalTitle = null;
 function drawSvgBbox(img, svg, bbox) {
     if (!bbox || bbox.length !== 4 || (bbox[0] === 0 && bbox[1] === 0 && bbox[2] === 0 && bbox[3] === 0)) return;
     // Use displayed size
@@ -116,6 +117,10 @@ function showModalForIndex(index) {
     var bbox = null;
     try { if (bboxStr) bbox = JSON.parse(bboxStr); } catch (e) {}
     showModalWithImageAndBbox(img.getAttribute('data-image-url'), bbox);
+    if (modalTitle) {
+        var ts = img.getAttribute('data-timestamp');
+        modalTitle.textContent = ts ? 'Image Preview - ' + ts : 'Image Preview';
+    }
     if (prevBtn) {
         prevBtn.style.display = index <= 0 ? 'none' : 'block';
     }
@@ -129,6 +134,7 @@ function showModalForIndex(index) {
 
 document.addEventListener('DOMContentLoaded', function () {
     renderBboxOverlays();
+    modalTitle = document.getElementById('imageModalLabel');
     modalImages = Array.from(document.querySelectorAll('.clickable-image'));
     modalImages.forEach(function (img, idx) {
         img.dataset.modalIndex = idx;

--- a/static/js/table_scripts.js
+++ b/static/js/table_scripts.js
@@ -116,3 +116,13 @@ function sortTable(tableId, value) {
     currentUrl.searchParams.set('page', '1');
     window.location.href = currentUrl.toString();
 }
+
+function changeLimit(value) {
+    if (!value) return;
+    const currentUrl = new URL(window.location.href);
+    currentUrl.searchParams.set('limit', value);
+    currentUrl.searchParams.delete('next_token');
+    currentUrl.searchParams.delete('prev_token');
+    currentUrl.searchParams.set('page', '1');
+    window.location.href = currentUrl.toString();
+}

--- a/static/js/table_scripts.js
+++ b/static/js/table_scripts.js
@@ -13,81 +13,21 @@ function initDataTable(tableId) {
         $('#' + tableId).DataTable().destroy();
     }
     tableElement.addClass('dt-table-' + tableId);
+    var pageLimitAttr = parseInt(tableElement.data('page-limit'));
+    if (isNaN(pageLimitAttr)) {
+        pageLimitAttr = tableElement.find('tbody tr').length;
+    }
     var table = tableElement.DataTable({
-        paging: true,
+        paging: false,
         searching: false,
         ordering: false,
-        info: true,
-        lengthMenu: [[10, 25, 50, -1], [10, 25, 50, 'All']],
+        info: false,
+        pageLength: pageLimitAttr,
         dom: 't',
         autoWidth: true,
         responsive: true,
         scrollX: true,
-        scrollCollapse: true,
-        initComplete: function () {
-            // Length control
-            var lengthHtml = '<label>Show <select name="' + tableId + '_length" aria-controls="' + tableId + '" class="form-select form-select-sm">' +
-                '<option value="10">10</option>' +
-                '<option value="25">25</option>' +
-                '<option value="50">50</option>' +
-                '<option value="-1">All</option>' +
-                '</select> entries</label>';
-            $('#' + tableId + '_length').html(lengthHtml);
-            // Connect length control
-            $('#' + tableId + '_length select').on('change', function () {
-                table.page.len($(this).val()).draw();
-            });
-            // Info display
-            var updateInfo = function () {
-                var info = table.page.info();
-                var infoText = 'Showing ' + (info.start + 1) + ' to ' + info.end + ' of ' + info.recordsDisplay + ' entries';
-                if (info.recordsDisplay != info.recordsTotal) {
-                    infoText += ' (filtered from ' + info.recordsTotal + ' total entries)';
-                }
-                $('#' + tableId + '_info').html(infoText);
-            };
-            updateInfo();
-            table.on('draw', updateInfo);
-            // Pagination
-            var createPagination = function () {
-                var info = table.page.info();
-                var html = '<ul class="pagination">';
-                html += '<li class="paginate_button page-item previous ' + (info.page === 0 ? 'disabled' : '') + '">' +
-                    '<a href="#" class="page-link" data-page="prev">Previous</a></li>';
-                var startPage = Math.max(0, info.page - 2);
-                var endPage = Math.min(info.pages - 1, info.page + 2);
-                if (startPage > 0) {
-                    html += '<li class="paginate_button page-item"><a href="#" class="page-link" data-page="0">1</a></li>';
-                    if (startPage > 1) html += '<li class="paginate_button page-item disabled"><a href="#" class="page-link">...</a></li>';
-                }
-                for (var i = startPage; i <= endPage; i++) {
-                    html += '<li class="paginate_button page-item ' + (i === info.page ? 'active' : '') + '">' +
-                        '<a href="#" class="page-link" data-page="' + i + '">' + (i + 1) + '</a></li>';
-                }
-                if (endPage < info.pages - 1) {
-                    if (endPage < info.pages - 2) html += '<li class="paginate_button page-item disabled"><a href="#" class="page-link">...</a></li>';
-                    html += '<li class="paginate_button page-item"><a href="#" class="page-link" data-page="' + (info.pages - 1) + '">' + info.pages + '</a></li>';
-                }
-                html += '<li class="paginate_button page-item next ' + (info.page === info.pages - 1 ? 'disabled' : '') + '">' +
-                    '<a href="#" class="page-link" data-page="next">Next</a></li>';
-                html += '</ul>';
-                $('#' + tableId + '_paginate').html(html);
-                // Event handlers
-                $('#' + tableId + '_paginate .page-link').on('click', function (e) {
-                    e.preventDefault();
-                    var page = $(this).data('page');
-                    if (page === 'prev') {
-                        table.page('previous').draw('page');
-                    } else if (page === 'next') {
-                        table.page('next').draw('page');
-                    } else {
-                        table.page(page).draw('page');
-                    }
-                });
-            };
-            createPagination();
-            table.on('draw', createPagination);
-        }
+        scrollCollapse: true
     });
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -158,10 +158,12 @@
                 </div>
                 <div class="modal-body p-0">
                     <div style="position: relative; width: 100%; text-align: center;">
+                        <button id="modal-prev" type="button" class="btn btn-secondary modal-nav-btn" style="position:absolute;top:50%;left:0;transform:translateY(-50%);z-index:1051;">&laquo;</button>
                         <img id="modal-image" class="img-fluid" style="max-height: 80vh; margin: 0 auto;">
                         <svg id="modal-bbox-svg" class="bbox-svg-overlay" style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none;">
                             <polygon points="" style="fill: none; stroke: #ff0000; stroke-width: 2;"></polygon>
                         </svg>
+                        <button id="modal-next" type="button" class="btn btn-secondary modal-nav-btn" style="position:absolute;top:50%;right:0;transform:translateY(-50%);z-index:1051;">&raquo;</button>
                     </div>
                 </div>
                 <div class="modal-footer">

--- a/templates/device_classifications.html
+++ b/templates/device_classifications.html
@@ -7,13 +7,22 @@
 {% block content %}
 <div class="container">
     <h2>Device {{ device_id }} Classifications</h2>
+    <div class="mb-3">
+        <label for="limitSelect">Items per page:</label>
+        <select id="limitSelect" class="form-control d-inline-block w-auto ml-2" onchange="changeLimit(this.value)">
+            {% for option in [50, 100, 200, 500] %}
+            <option value="{{ option }}" {% if limit == option %}selected{% endif %}>{{ option }}</option>
+            {% endfor %}
+        </select>
+    </div>
     {% set display_fields = fields + ['formatted_time'] if 'formatted_time' not in fields else fields %}
     {{ render_table('classificationsTable', classifications, display_fields,
     url_for('download_csv', table_type='classifications', device_id=device_id), pagination,
-    request.args.get('sort_by'), request.args.get('sort_order')) }}
+    current_sort_by, current_sort_desc, limit) }}
 </div>
 {% endblock %}
 
 {% block scripts %}
 {{ table_scripts('classificationsTable') }}
+<script src="{{ url_for('static', filename='js/table_scripts.js') }}"></script>
 {% endblock %}

--- a/templates/table.html
+++ b/templates/table.html
@@ -30,7 +30,7 @@ current_sort_desc=None, page_limit=50) %}
 
 <!-- Table within scrollable area -->
 <div class="table-responsive">
-    <table id="{{ table_id }}" data-table-id="{{ table_id }}" class="table table-bordered table-hover">
+    <table id="{{ table_id }}" data-table-id="{{ table_id }}" data-page-limit="{{ page_limit }}" class="table table-bordered table-hover">
         <thead>
             <tr>
                 {% for header in headers %}

--- a/templates/table.html
+++ b/templates/table.html
@@ -49,7 +49,8 @@ current_sort_desc=None, page_limit=50) %}
                         <img src="{{ item.image_url }}" class="img-fluid detection-img clickable-image"
                             style="max-height: 100px; display: block; cursor: pointer;"
                             data-image-url="{{ item.image_url }}"
-                            data-bbox="{{ bbox|tojson if bbox and bbox|length==4 else 'null' }}">
+                            data-bbox="{{ bbox|tojson if bbox and bbox|length==4 else 'null' }}"
+                            data-timestamp="{{ item.get('formatted_time', item.get('timestamp', '')) }}">
                         <!-- DEBUG: bbox for image_url={{ item.image_url }} is {{ bbox }} -->
 
                         {% if bbox and bbox|length == 4 %}

--- a/templates/table.html
+++ b/templates/table.html
@@ -1,5 +1,5 @@
 {% macro render_table(table_id, items, headers, download_url, pagination=None, current_sort_by=None,
-current_sort_desc=None) %}
+current_sort_desc=None, page_limit=50) %}
 <!-- Controls outside of the table-responsive area -->
 <div class="mb-3">
     <div class="d-flex justify-content-between align-items-center">
@@ -25,7 +25,7 @@ current_sort_desc=None) %}
 </div>
 
 <div class="mb-3 d-flex justify-content-between align-items-center">
-    <div id="{{ table_id }}_info" class="dataTables_info">Showing up to 50 items per page</div>
+    <div id="{{ table_id }}_info" class="dataTables_info">Showing up to {{ page_limit }} items per page</div>
 </div>
 
 <!-- Table within scrollable area -->


### PR DESCRIPTION
## Summary
- make `fetch_data` accept a configurable limit
- add limit handling to classification page route
- include selected limit in pagination URLs and template
- add dropdown to choose items per page
- load new JavaScript helper and expose `changeLimit` function
- add modal arrow navigation for bounding box images

## Testing
- `python -m py_compile app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68437c4ed6548326b6457a24297d6a1f