### PR TITLE
Update table sort param

### DIFF
--- a/templates/device_classifications.html
+++ b/templates/device_classifications.html
@@ -10,7 +10,7 @@
     {% set display_fields = fields + ['formatted_time'] if 'formatted_time' not in fields else fields %}
     {{ render_table('classificationsTable', classifications, display_fields,
     url_for('download_csv', table_type='classifications', device_id=device_id), pagination,
-    request.args.get('sort_by'), request.args.get('sort_order')) }}
+    request.args.get('sort_by'), request.args.get('sort_desc') == 'true') }}
 </div>
 {% endblock %}
 

--- a/templates/device_detections.html
+++ b/templates/device_detections.html
@@ -11,7 +11,7 @@
     {% set display_fields = detections[0].keys()|sort %}
     {{ render_table('detectionsTable', detections, display_fields,
     url_for('download_csv', table_type='detections', device_id=device_id), pagination,
-    request.args.get('sort_by'), request.args.get('sort_order')) }}
+    request.args.get('sort_by'), request.args.get('sort_desc') == 'true') }}
     {% else %}
     {% endif %}
 </div>

--- a/templates/models.html
+++ b/templates/models.html
@@ -29,7 +29,7 @@
 
     {{ render_table('modelsTable', models, field_names,
     url_for('download_csv', table_type='models', device_id=None), pagination,
-    request.args.get('sort_by'), request.args.get('sort_order')) }}
+    request.args.get('sort_by'), request.args.get('sort_desc') == 'true') }}
 
     {% else %}
     <div class="alert alert-info">


### PR DESCRIPTION
## Summary
- use `sort_desc` instead of deprecated `sort_order`
- keep dropdown selections working with `table_scripts.js`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c61c17d48326bb3bb922e988c249