### PR TITLE
Enable arrow key navigation in image modal

### DIFF
--- a/static/js/bbox_overlays.js
+++ b/static/js/bbox_overlays.js
@@ -160,6 +160,21 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
+    // Allow arrow key navigation while modal is open
+    document.addEventListener('keydown', function (e) {
+        var modal = document.getElementById('imageModal');
+        if (!modal || !modal.classList.contains('show')) return;
+        if (e.key === 'ArrowLeft') {
+            if (currentModalIndex > 0) {
+                showModalForIndex(currentModalIndex - 1);
+            }
+        } else if (e.key === 'ArrowRight') {
+            if (currentModalIndex < modalImages.length - 1) {
+                showModalForIndex(currentModalIndex + 1);
+            }
+        }
+    });
+
     window.addEventListener('resize', renderBboxOverlays);
 });
 


### PR DESCRIPTION
## Summary
- support left/right arrow navigation for modal images

## Testing
- `poetry run pytest`

------
https://chatgpt.com/codex/tasks/task_e_6843d8a372bc832696c638ba589a00f9