### PR TITLE
Add health endpoint test

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,29 @@ To add new dependencies to the project:
 poetry add package-name
 ```
 
+### Running Tests
+
+First install dependencies (if not already done):
+
+```bash
+poetry install --no-root
+```
+
+Run the test suite using Poetry's virtual environment:
+
+```bash
+poetry run pytest -q
+```
+
+### Health Check Endpoint
+
+After starting the dashboard you can verify that it is running by hitting the
+`/health` endpoint:
+
+```bash
+curl http://localhost:8080/health
+```
+
 ### Deploying to AWS AppRunner
 
 This application is configured to be deployable to AWS AppRunner. The Docker container setup provides the necessary configuration for cloud deployment.

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+# Ensure project root is in PYTHONPATH
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Provide dummy environment variables required for importing app
+os.environ.setdefault("API_BASE_URL", "http://localhost")
+os.environ.setdefault("SENSING_GARDEN_API_KEY", "dummy-key")
+
+from app import app
+
+
+def test_health_endpoint():
+    with app.test_client() as client:
+        response = client.get('/health')
+        assert response.status_code == 200
+        data = response.get_json()
+        assert isinstance(data, dict)
+        for key in ["status", "timestamp", "environment", "message"]:
+            assert key in data


### PR DESCRIPTION
## Summary
- add pytest for `/health` endpoint using Flask test client
- document running tests and using `/health` endpoint

## Testing
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843c63676bc8326afe5ee6836c84b63